### PR TITLE
Provide pre-compiled binaries for everyone to use.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,10 @@
+# Why does this fork exist?
+This is a fork of the JXRLib code which aims to provide an easy to access compiled binary of JXRDecApp.exe and JXREncApp.exe. 
+For some reason they only ever released an uncompiled version and no one seems to have decided to make the compiled version easy to access for others. 
+So here I am to do that for everyone.
+
+Original repository: https://github.com/4creators/jxrlib
+
 # jxrlib
 ### JPEG XR Format
 JPEG XR is a still image format based on

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Why does this fork exist?
-This is a fork of the JXRLib code which aims to provide an easy to access compiled binary of JXRDecApp.exe and JXREncApp.exe. 
-For some reason they only ever released an uncompiled version and no one seems to have decided to make the compiled version easy to access for others. 
+This is a fork of the JXRLib code which aims to provide an easy to access to the compiled binary of JXRDecApp.exe and JXREncApp.exe. 
+For some reason they only ever released an uncompiled version of it and no one seems to have decided to make the compiled version easy to access for others. 
 So here I am to do that for everyone.
 
 Original repository: https://github.com/4creators/jxrlib


### PR DESCRIPTION
Not sure why this wasn't done to begin with, it adds unneeded workloads for developers. 

I have provided the compiled binaries for everyone in a [fork](https://github.com/Knewest/precompiled-jxrlib-binaries/releases/tag/Release-v2019.10.9) and attached them below.

Precompiled binaries:
[LibJXRv2019.10.9_All-In-One.zip](https://github.com/4creators/jxrlib/files/11094459/LibJXRv2019.10.9_All-In-One.zip)
[LibJXRv2019.10.9_Debug_Win32.zip](https://github.com/4creators/jxrlib/files/11094463/LibJXRv2019.10.9_Debug_Win32.zip)
[LibJXRv2019.10.9_Debug_x64.zip](https://github.com/4creators/jxrlib/files/11094466/LibJXRv2019.10.9_Debug_x64.zip)
[LibJXRv2019.10.9_Release_Win32.zip](https://github.com/4creators/jxrlib/files/11094469/LibJXRv2019.10.9_Release_Win32.zip)
[LibJXRv2019.10.9_Release_x64.zip](https://github.com/4creators/jxrlib/files/11094471/LibJXRv2019.10.9_Release_x64.zip)